### PR TITLE
Fix gazebo launch path variable

### DIFF
--- a/so101_sim/launch/so101_sim_gazebo.launch.py
+++ b/so101_sim/launch/so101_sim_gazebo.launch.py
@@ -20,7 +20,7 @@ def generate_launch_description():
         description="Absolute path to the robot URDF/xacro file"
         )
 
-    gazebo_resuorce_path = SetEnvironmentVariable(
+    gazebo_resource_path = SetEnvironmentVariable(
         name="GZ_SIM_RESOURCE_PATH",
         value=[
             str(Path(so101_description_share_dir).parent.resolve())
@@ -81,7 +81,7 @@ def generate_launch_description():
 
     return LaunchDescription([
         model_arg,
-        gazebo_resuorce_path,
+        gazebo_resource_path,
         robot_state_publisher,
         gazebo_launch,
         gazebo_spawn_entity,


### PR DESCRIPTION
## Summary
- keep the correct ros2-gz bridge clock argument format
- retain corrected resource path variable

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68556c9f2380832696bbb09415444261