### PR TITLE
Fix exec_depend reference

### DIFF
--- a/so101_controller/package.xml
+++ b/so101_controller/package.xml
@@ -19,7 +19,7 @@
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>
   <exec_depend>controller_manager</exec_depend>
-  <exec_depend>arduinobot_description</exec_depend>
+  <exec_depend>so101_description</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
## Summary
- update exec dependency for the controller package from `arduinobot_description` to `so101_description`

## Testing
- `colcon test --event-handlers console_cohesion+ --packages-select so101_controller` *(fails: `colcon` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68556e6afcf883268185d2885025562c