### PR TITLE
Add basic flake8 workflow

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 100
+extend-ignore = E203

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,0 +1,20 @@
+name: Lint
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  flake8:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install flake8
+      - name: Run flake8
+        run: flake8

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ install_manifest.txt
 .moveit_ci/
 docs_output
 docs_build
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # so101_ros2
 A ros2 driver for Lerobot so101 manipulator
+
+## Development
+
+Linting is checked with [flake8](https://flake8.pycqa.org/) via GitHub Actions.
+Run `flake8` locally before submitting changes.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run flake8
- add flake8 configuration
- ignore Python cache files
- document linting instructions in README

## Testing
- `flake8` *(fails: command not found)*
- `pip install flake8` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685570d7d6ac832696dd6e83bc3c4638