### PR TITLE
Add clang format style config

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,3 @@
+BasedOnStyle: Google
+IndentWidth: 4
+ColumnLimit: 100


### PR DESCRIPTION
## Summary
- add a `.clang-format` file so ament_clang_format uses Google style

## Testing
- `pre-commit run --files .clang-format` *(fails: command not found)*
- `ament_clang_format --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867976805f883269e824608dd118dee