### PR TITLE
Add clang-format lint workflow

### DIFF
--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -1,0 +1,25 @@
+name: Clang Format
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+
+jobs:
+  clang-format:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-format
+          pip install colcon-common-extensions ament-lint
+      - name: Run clang-format
+        run: colcon test
+        env:
+          BUILD_TESTING: '1'

--- a/so101_controller/CMakeLists.txt
+++ b/so101_controller/CMakeLists.txt
@@ -17,6 +17,7 @@ install(
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
+  find_package(ament_clang_format REQUIRED)
   # the following line skips the linter which checks for copyrights
   # comment the line when a copyright and license is added to all source files
   set(ament_cmake_copyright_FOUND TRUE)

--- a/so101_description/CMakeLists.txt
+++ b/so101_description/CMakeLists.txt
@@ -36,8 +36,9 @@ install(
 )
 
 if(BUILD_TESTING)
-	find_package(ament_lint_auto REQUIRED)
-	ament_lint_auto_find_test_dependencies()
+        find_package(ament_lint_auto REQUIRED)
+        find_package(ament_clang_format REQUIRED)
+        ament_lint_auto_find_test_dependencies()
 endif()
 
 ament_package()

--- a/so101_moveit/CMakeLists.txt
+++ b/so101_moveit/CMakeLists.txt
@@ -19,6 +19,7 @@ install(
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
+  find_package(ament_clang_format REQUIRED)
   # the following line skips the linter which checks for copyrights
   # comment the line when a copyright and license is added to all source files
   set(ament_cmake_copyright_FOUND TRUE)

--- a/so101_ros2/CMakeLists.txt
+++ b/so101_ros2/CMakeLists.txt
@@ -3,4 +3,10 @@ project(so101_ros2)
 
 find_package(ament_cmake REQUIRED)
 
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  find_package(ament_clang_format REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
 ament_package()

--- a/so101_sim/CMakeLists.txt
+++ b/so101_sim/CMakeLists.txt
@@ -20,4 +20,10 @@ install(DIRECTORY config
   OPTIONAL
 )
 
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  find_package(ament_clang_format REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
 ament_package()

--- a/so101_teleop/CMakeLists.txt
+++ b/so101_teleop/CMakeLists.txt
@@ -137,4 +137,10 @@ install(DIRECTORY config DESTINATION share/${PROJECT_NAME})
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
 
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  find_package(ament_clang_format REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
 ament_package()


### PR DESCRIPTION
## Summary
- hook up clang format lint to CMake
- check formatting in CI
- fix clang-format workflow runner to `ubuntu-22.04`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686704ebcc448326a87b92962ecd653d