### PR TITLE
Add basic Sphinx documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ to the `main` and `dev` branches.
 - [ ] Clean code and refactoring
 - [ ] Add integration with isaacSim/Lab
 - [ ] Add externals (sdr pkg)
-- [ ] Add Docs with sphyncs
 - [ ] Improve readme and check installation process
 - [ ] Fix teleoperate with gazebo
 - [ ] Add teleoperate functionalities with joy (and keyboard?)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,14 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath('..'))
+
+project = 'SO101 ROS2'
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
+]
+templates_path = ['_templates']
+exclude_patterns = []
+
+html_theme = 'alabaster'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,11 @@
+SO101 ROS2 Documentation
+========================
+
+Welcome to the documentation for the SO101 ROS2 workspace. This project provides
+an open-source ROS 2 driver for the Lerobot SO101 manipulator.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   overview

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -1,0 +1,15 @@
+Overview
+========
+
+The SO101 ROS2 workspace brings together packages for description files,
+controllers, MoveIt configurations and Gazebo simulation of the SO101 arm.
+It allows you to visualise the robot model, control it with ROS 2 control and
+run a simulation environment for testing and development.
+
+Packages
+--------
+
+- ``so101_description`` – URDF and meshes for the robot.
+- ``so101_controller`` – ROS 2 control nodes and configuration.
+- ``so101_sim`` – Gazebo simulation launch files.
+- ``so101_moveit`` – MoveIt configuration for planning.


### PR DESCRIPTION
## Summary
- scaffold Sphinx docs with simple overview
- clean up README TODO after adding docs

## Testing
- `sphinx-build -b html docs docs/_build` *(fails: command not found)*
- `pytest` *(fails: No module named 'ament_copyright')*

------
https://chatgpt.com/codex/tasks/task_e_68c1933cabd08326b0a1d813f8416578