### PR TITLE
Expand documentation for SO101 bring-up and setup

### DIFF
--- a/docs/bringup.rst
+++ b/docs/bringup.rst
@@ -1,0 +1,42 @@
+Bring-up
+========
+
+Real hardware
+-------------
+Use ``so101_bringup/launch/so101_robot.launch.py`` to start either the follower
+or leader hardware stack. The launch file exposes the ``type`` argument to pick
+the robot role and forwards the ``model`` and ``display`` options to the
+underlying description launch files. For example, to start the follower arm with
+RViz::
+
+   ros2 launch so101_bringup so101_robot.launch.py type:=follower display:=true
+
+When ``type:=follower`` is selected the launch file loads
+``include/follower.launch.py`` which in turn brings up the robot state publisher
+for the real hardware, the Python bridge node and the ros2_control controller
+manager with timed spawners for the arm and gripper controllers. Selecting
+``type:=leader`` activates the analogous stack defined in
+``include/leader.launch.py``.
+
+The ``display_config`` argument may be used to pick a custom RViz configuration
+and ``model`` can be set to an alternative URDF if needed. For setups with
+cameras, ``so101_robot_with_cameras.launch.py`` extends the bring-up with the USB
+camera pipeline before optionally launching RViz.
+
+Simulation
+----------
+Gazebo bring-up is provided by ``so101_bringup/launch/so101_sim_gazebo.launch.py``.
+The launch file forwards the ``model`` argument to the robot description and can
+start RViz when ``display:=true``. Internally it loads
+``include/sim_gazebo.launch.py`` which spawns the robot state publisher in
+simulation mode, launches the Gazebo environment from ``so101_sim`` and spawns
+the follower ros2_control controllers so that planning and teleoperation stacks
+see the same interfaces as the hardware.
+
+MoveIt integration
+------------------
+For motion planning use ``so101_bringup/launch/so101_moveit.launch.py``. It can
+switch between real hardware and Gazebo simulation via the ``mode`` argument and
+always launches the MoveIt configuration from ``so101_moveit``. When running in
+Gazebo, the launch file reuses ``include/sim_gazebo.launch.py`` so the MoveIt
+nodes are connected to the simulated controller interface.

--- a/docs/datacollection.rst
+++ b/docs/datacollection.rst
@@ -1,0 +1,20 @@
+Data collection
+===============
+
+System Data Recorder
+--------------------
+The repository provides ``so101_bringup/launch/so101_record.launch.py`` to start
+the ``system_data_recorder`` node with a preconfigured parameter file. Launching
+it will record the topics listed in the configuration while mirroring the output
+into the configured destination directory::
+
+   ros2 launch so101_bringup so101_record.launch.py
+
+Configuration
+-------------
+Parameters for the recorder are stored in ``so101_bringup/config/so101_sdr.yaml``.
+The default setup writes bag files prefixed with ``robot_data`` to the path in
+``copy_destination`` and records ``/joint_states`` as ``sensor_msgs/msg/JointState``.
+Extend the ``topic_names`` and ``topic_types`` arrays to capture additional
+datasets and adjust the ``max_file_size`` limit to control bag splitting during
+long sessions.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,3 +9,14 @@ an open-source ROS 2 driver for the Lerobot SO101 manipulator.
    :caption: Contents:
 
    overview
+   installation
+   setup
+   bringup
+   ros2controlarch
+   teleop
+   datacollection
+
+Acknowledgments
+---------------
+The SO101 ROS 2 bridge builds on the Lerobot project from Hugging Face for the
+leader and follower device APIs used throughout the bridge implementation.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,0 +1,31 @@
+Installation
+============
+
+System requirements
+-------------------
+- ROS 2 Humble with the CycloneDDS RMW implementation as used throughout the workspace.  
+- Gazebo Fortress (Ignition) for simulation bring-up.  
+- A working build toolchain for `colcon` workspaces.
+
+Clone and build
+---------------
+1. Create or reuse a ROS 2 workspace and clone the repository into the ``src`` folder::
+
+       mkdir -p ~/ros2_ws/src
+       cd ~/ros2_ws/src
+       git clone https://github.com/<your-org>/so101_ros2.git
+
+2. Install ROS 2 package dependencies with ``rosdep`` and build the workspace::
+
+       cd ~/ros2_ws
+       rosdep install --from-paths src --ignore-src -r -y
+       colcon build
+       source install/setup.bash
+
+Python dependencies
+-------------------
+The ROS 2 bridge nodes rely on the Hugging Face `lerobot` project for the SO101
+leader and follower APIs. Ensure the library is available in the Python
+environment used to launch the ROS 2 nodes. If ``lerobot`` is installed in a
+separate Conda environment, expose its ``site-packages`` directory through the
+``LECONDA_SITE_PACKAGES`` environment variable before running the bridge nodes.

--- a/docs/ros2controlarch.rst
+++ b/docs/ros2controlarch.rst
@@ -1,0 +1,32 @@
+ROS 2 Control Architecture
+==========================
+
+Hardware interface
+------------------
+The ``so101_hardware_interface`` package exposes a ``SystemInterface`` plugin
+named ``so101_hardware_interface/So101HardwareBridge``. It creates a dedicated
+ROS 2 node that publishes commands on the ``joint_commands`` topic and subscribes
+to raw joint states from the Python bridge on ``joint_states_raw``. Incoming
+joint states are matched against the URDF joint order before being stored in the
+ros2_control state buffers, while outgoing commands stream the latest controller
+set-points back to the Python layer. The plugin is exported in
+``so101_hardware_bridge_plugins.xml`` so it can be referenced from the URDF.
+
+Controller layout
+-----------------
+Controller definitions live in ``so101_controller/config/so101_controllers.yaml``.
+The follower namespace loads a ``joint_trajectory_controller`` for the arm, a
+``GripperActionController`` and a joint state broadcaster. The leader namespace
+runs only a joint state broadcaster, reflecting its use as a sensing device. The
+configuration keeps both command and state interfaces in position mode to match
+the bridge expectations.
+
+Launch files
+------------
+``so101_controller/launch/controller_manager.launch.py`` starts the
+``ros2_control_node`` with the controller configuration. The separate launch file
+``so101_controller/launch/so101_controllers.launch.py`` spawns the joint state
+broadcaster before the arm and gripper controllers under the namespace provided
+through the ``type`` launch argument. The bring-up launch descriptions use timer
+actions to delay controller spawning until the hardware interfaces and bridge
+nodes are online.

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -1,0 +1,45 @@
+Setup
+=====
+
+Bridge configuration
+--------------------
+The ROS 2 bridge nodes read their default parameters from the YAML files in
+``so101_ros2_bridge/config``. Update the serial port, robot identifier and
+calibration directory to match the hardware that is connected to the machine::
+
+   so101_ros2_bridge/config/so101_follower_params.yaml
+   so101_ros2_bridge/config/so101_leader_params.yaml
+
+Each file defines the ``port``, ``id`` and ``publish_rate`` fields used by the
+Python bridge node. The follower configuration additionally exposes
+``max_relative_target`` and ``disable_torque_on_disconnect`` to bound commands
+sent to the arm.
+
+Calibration assets
+------------------
+Default calibration JSON files are installed with the package under
+``so101_ros2_bridge/config/calibration``. Replace or extend these files with the
+calibration data generated for your manipulators and point the parameter files
+to the desired directory when launching.
+
+Python environment
+------------------
+The bridge code dynamically adds the Lerobot Conda environment to ``sys.path``
+using the ``LECONDA_SITE_PACKAGES`` environment variable. Ensure the variable
+points to the ``site-packages`` directory that contains the ``lerobot``
+distribution before starting the ROS 2 bridge nodes.
+
+Cameras
+-------
+USB camera support is defined in ``so101_bringup/config/so101_cameras.yaml``.
+Each entry references a USB camera parameter file such as
+``so101_bringup/config/so101_usb_cam_front.yaml`` where the device path,
+resolution and exposure settings are declared. Update these files to match the
+connected cameras.
+
+System data recorder
+--------------------
+The data recording launch file loads ``so101_bringup/config/so101_sdr.yaml`` to
+configure the ``system_data_recorder`` node. Adjust the ``copy_destination``,
+``bag_name_prefix`` and the list of topics to capture the information required
+for your workflows before running a recording session.

--- a/docs/teleop.rst
+++ b/docs/teleop.rst
@@ -1,0 +1,32 @@
+Teleoperation
+=============
+
+Component overview
+------------------
+The ``so101_teleop`` package provides the ``LeaderTeleopComponent`` ROS 2
+component. It subscribes to the leader robot joint states, buffers the joint name
+ordering on the first message and publishes streaming ``JointTrajectory``
+messages for the follower arm. The trajectory points mirror the current leader
+positions with a short ``time_from_start`` so controllers can track the data as a
+continuous stream.
+
+Parameters
+----------
+Default parameters are stored in ``so101_teleop/config/so101_leader_teleop.yaml``.
+The ``leader_joint_states_topic`` selects the input topic (``/leader/joint_states``
+by default) and ``follower_trajectory_topic`` configures the target controller
+interface (``/follower/arm_controller/joint_trajectory`` by default).
+
+Launching
+---------
+``so101_bringup/launch/so101_teleoperate.launch.py`` orchestrates a complete
+teleoperation session. It brings up the leader stack first, optionally the
+follower hardware, and finally loads the teleoperation component inside a
+multithreaded component container. Use the ``mode`` argument to switch between
+real hardware and Gazebo simulation::
+
+   ros2 launch so101_bringup so101_teleoperate.launch.py mode:=real
+
+When ``mode:=gazebo`` the launch file skips the follower hardware bring-up and
+runs with simulated time while still attaching the teleoperation component to the
+leader bridge output.


### PR DESCRIPTION
## Summary
- add installation and setup guides covering workspace preparation and configuration details
- document bring-up, ros2_control architecture, teleoperation, and data collection workflows
- update the documentation index with the new sections and a Lerobot acknowledgment

## Testing
- `sphinx-build -b html docs docs/_build/html`


------
https://chatgpt.com/codex/tasks/task_e_68c8faca3890832698267f12daf15190